### PR TITLE
ci: declare permissions on three workflows

### DIFF
--- a/.github/workflows/license-check.yaml
+++ b/.github/workflows/license-check.yaml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   license-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/new_pr.yml
+++ b/.github/workflows/new_pr.yml
@@ -3,6 +3,9 @@ on:
     pull_request:
         branches: [main]
         types: [opened, reopened, ready_for_review, synchronize]
+
+permissions: {}   # the slack post only reads github.event.pull_request fields; no GitHub API calls
+
 jobs:
     notify:
         name: Slack notification

--- a/.github/workflows/runtimes-ci.yaml
+++ b/.github/workflows/runtimes-ci.yaml
@@ -5,6 +5,9 @@ on:
     pull_request:
         branches: [main]
 
+permissions:
+    contents: read
+
 jobs:
     test:
         name: Test


### PR DESCRIPTION
Three workflows ran without explicit permissions:

- `license-check.yaml` and `runtimes-ci.yaml` — pure CI (`contents: read` for checkout).
- `new_pr.yml` — only posts a Slack notification via webhook using `github.event.pull_request` fields. No checkout, no GitHub API. `permissions: {}` (deny all scopes) is correct.