### PR TITLE
fix: pin vscode-languageserver family to a single version to prevent duplicate copies

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,10 @@
         "cross-spawn": "^7.0.6",
         "prebuild-install": "^7.0.0",
         "protobufjs": "^7.5.6",
-        "node-forge": "^1.4.0"
+        "node-forge": "^1.4.0",
+        "vscode-languageserver-protocol": "3.17.5",
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
     },
     "typesVersions": {
         "*": {


### PR DESCRIPTION
## Problem
`vscode-languageserver@9.0.1` hard-depends on `vscode-languageserver-protocol@3.17.5`
(exact), but `runtimes/package.json` declares `^3.17.5`. When the lockfile is
re-resolved (e.g. downstream Brazil builds via NpmPrettyMuch), the top level floats up
to `vscode-languageserver-protocol@3.18.1` / `vscode-jsonrpc@9.0.0` /
`vscode-languageserver-types@3.18.0`, while `vscode-languageserver@9.0.1` keeps a nested
copy of the `3.17.5` set. TypeScript then sees two incompatible copies of the same types
and fails with 59 errors (TS2769 / TS2345 "separate declarations of private property
'kind'/'_parameterStructures'", TS2308 duplicate `ServerInfo` export, TS7006). This
broke the downstream build (build.amazon.com/7904668317 and follow-ups) and is latent in
this repo (only masked by the currently committed lockfile).

## Solution
Add npm `overrides` pinning the family to the single consistent set that
`vscode-languageserver@9.0.1` requires:
- `vscode-languageserver-protocol`: `3.17.5`
- `vscode-jsonrpc`: `8.2.0`
- `vscode-languageserver-types`: `3.17.5`

This guarantees a single deduplicated copy regardless of how/when the lockfile is
regenerated, and matches the versions already resolved on `main`.

## Testing
- `npm run compile` -> 0 TS errors (was 59)
- `npm test` -> all passing
- No nested `vscode-languageserver/node_modules/vscode-*` copies remain
- Verified end-to-end in a Brazil workspace build of DEXPLanguageServerRuntimes:
  BUILD SUCCEEDED, 0 TS errors, 247 tests passing / 3 pending / 0 failing.

## Follow-up
After merge + release, ReplicaSyncBot will sync this into DEXPLanguageServerRuntimes'
`amazon` branch, which unblocks the FlareOperationalTelemetry VersionSet auto-merge build.