### PR TITLE
fix: update repository URLs to the Amazon-Q-Developer org

### DIFF
--- a/chat-client-ui-types/package.json
+++ b/chat-client-ui-types/package.json
@@ -12,7 +12,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/aws/language-server-runtimes",
+        "url": "https://github.com/Amazon-Q-Developer/language-server-runtimes",
         "directory": "chat-client-ui-types"
     },
     "author": "Amazon Web Services",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     ],
     "repository": {
         "type": "git",
-        "url": "https://github.com/aws/language-server-runtimes"
+        "url": "https://github.com/Amazon-Q-Developer/language-server-runtimes"
     },
     "author": "Amazon Web Services",
     "license": "Apache-2.0",

--- a/runtimes/package.json
+++ b/runtimes/package.json
@@ -4,7 +4,7 @@
     "description": "Runtimes to host Language Servers for AWS",
     "repository": {
         "type": "git",
-        "url": "https://github.com/aws/language-server-runtimes",
+        "url": "https://github.com/Amazon-Q-Developer/language-server-runtimes",
         "directory": "runtimes"
     },
     "author": "Amazon Web Services",

--- a/types/package.json
+++ b/types/package.json
@@ -12,7 +12,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/aws/language-server-runtimes",
+        "url": "https://github.com/Amazon-Q-Developer/language-server-runtimes",
         "directory": "types"
     },
     "author": "Amazon Web Services",


### PR DESCRIPTION
## Problem

The repo was transferred from `aws/language-server-runtimes` to `Amazon-Q-Developer/language-server-runtimes` (P490405278), but `repository.url` in the root and all three published workspaces still points at the old org.

Publishing uses OIDC trusted publishing (`id-token: write` in `release-please.yaml`, no stored npm token), and all three packages carry SLSA provenance attestations. npm validates `repository.url` against the OIDC claims of the building repository when generating provenance, so a stale URL fails the publish step.

## Solution

Update `repository.url` in the four `package.json` files to the new org.

Typed `fix:` rather than `build:` so release-please generates a release PR — the corrected URLs only take effect once published. This bumps all three packages by a patch.

Deliberately unchanged:

- `@aws/*` package names and imports — that is the npm scope, unrelated to the GitHub org.
- Generated `CHANGELOG.md` files — release-please owns these and the old links redirect.
- Links to other repos still in the `aws` org (`aws/language-servers`, `aws/mynah-ui`, `aws/aws-toolkit-vscode`, `aws/aws-toolkit-jetbrains`).

## Testing

`prettier --check` passes, JSON validity confirmed, and no `github.com/aws/language-server-runtimes` self-references remain outside generated changelogs.

## Note for maintainers

The npm **trusted publisher** config for all three packages has been repointed from `aws` to `Amazon-Q-Developer`. Both that and this change are required — the trusted publisher match gates the publish, and `repository.url` gates provenance generation within it.
