### PR TITLE
feat: notify servers when credentials are updated

### DIFF
--- a/runtimes/runtimes/auth/auth.ts
+++ b/runtimes/runtimes/auth/auth.ts
@@ -42,6 +42,7 @@ export class Auth {
     private credentialsEncoding: CredentialsEncoding | undefined
     private lspRouter: LspRouter
     private credentialsDeleteHandler?: (type: CredentialsType) => void
+    private credentialsUpdateHandler?: (type: CredentialsType) => void
 
     constructor(
         private readonly connection: Connection,
@@ -116,6 +117,9 @@ export class Auth {
             onCredentialsDeleted: (handler: (type: CredentialsType) => void) => {
                 this.credentialsDeleteHandler = handler
             },
+            onCredentialsUpdated: (handler: (type: CredentialsType) => void) => {
+                this.credentialsUpdateHandler = handler
+            },
         }
 
         this.registerLspCredentialsUpdateHandlers()
@@ -151,6 +155,9 @@ export class Auth {
 
             onCredentialsDeleted: (handler: (type: CredentialsType) => void) => {
                 this.credentialsDeleteHandler = handler
+            },
+            onCredentialsUpdated: (handler: (type: CredentialsType) => void) => {
+                this.credentialsUpdateHandler = handler
             },
         }
     }
@@ -239,11 +246,22 @@ export class Auth {
                 this.iamCredentials = creds as IamCredentials
                 // Prevent modifying credentials by implementors
                 Object.freeze(this.iamCredentials)
+                this.notifyCredentialsUpdate('iam')
             } else {
                 this.bearerCredentials = creds as BearerCredentials
                 Object.freeze(this.bearerCredentials)
+                this.notifyCredentialsUpdate('bearer')
             }
         }
+    }
+
+    /**
+     * Announces stored credentials so servers can start dependent work immediately instead of waiting
+     * for whatever happens to ask for a service first. Fired after the credentials are readable, and
+     * routed to every server the same way deletion is, so more than one server can react.
+     */
+    private notifyCredentialsUpdate(type: CredentialsType) {
+        this.lspRouter.onCredentialsUpdate(type)
     }
 
     private async decodeCredentialsRequestToken<T>(request: UpdateCredentialsParams): Promise<T> {

--- a/runtimes/runtimes/base-runtime.ts
+++ b/runtimes/runtimes/base-runtime.ts
@@ -325,6 +325,7 @@ export const baseRuntime = (connections: { reader: MessageReader; writer: Messag
         const sdkInitializator: SDKInitializator = <T, P>(Ctor: SDKClientConstructorV3<T, P>, current_config: P): T =>
             new Ctor({ ...current_config })
         credentialsProvider.onCredentialsDeleted = lspServer.setCredentialsDeleteHandler
+        credentialsProvider.onCredentialsUpdated = lspServer.setCredentialsUpdateHandler
 
         const agent = newAgent()
 

--- a/runtimes/runtimes/lsp/router/lspRouter.test.ts
+++ b/runtimes/runtimes/lsp/router/lspRouter.test.ts
@@ -415,6 +415,22 @@ describe('LspRouter', () => {
         })
     })
 
+    describe('onCredentialsUpdate', () => {
+        it('should send notifyCredentialsUpdate to all servers', () => {
+            const params: CredentialsType = 'bearer'
+
+            const spy1 = sandbox.spy()
+            const spy2 = sandbox.spy()
+            const server1 = newServer({ credentialsUpdateHandler: spy1 })
+            const server2 = newServer({ credentialsUpdateHandler: spy2 })
+
+            lspRouter.servers = [server1, server2]
+            lspRouter.onCredentialsUpdate(params)
+            assert(spy1.calledWith(params))
+            assert(spy2.calledWith(params))
+        })
+    })
+
     describe('handleGetConfigurationFromServer', () => {
         it(`should return the result from initializeResult cache for key: ${SERVER_CAPABILITES_CONFIGURATION_SECTION}`, async () => {
             const initHandler1 = () => {
@@ -1000,6 +1016,7 @@ describe('LspRouter', () => {
         initializedHandler,
         updateConfigurationHandler,
         credentialsDeleteHandler,
+        credentialsUpdateHandler,
         didChangeWorkspaceFoldersHandler,
         didCreateFilesHandler,
         didDeleteFilesHandler,
@@ -1014,6 +1031,7 @@ describe('LspRouter', () => {
         initializedHandler?: any
         updateConfigurationHandler?: any
         credentialsDeleteHandler?: any
+        credentialsUpdateHandler?: any
         didChangeWorkspaceFoldersHandler?: any
         didCreateFilesHandler?: any
         didDeleteFilesHandler?: any
@@ -1028,6 +1046,7 @@ describe('LspRouter', () => {
         server.setInitializedHandler(initializedHandler)
         server.setUpdateConfigurationHandler(updateConfigurationHandler)
         server.setCredentialsDeleteHandler(credentialsDeleteHandler)
+        server.setCredentialsUpdateHandler(credentialsUpdateHandler)
         server.setDidChangeWorkspaceFoldersHandler(didChangeWorkspaceFoldersHandler)
         server.setDidCreateFilesHandler(didCreateFilesHandler)
         server.setDidDeleteFilesHandler(didDeleteFilesHandler)

--- a/runtimes/runtimes/lsp/router/lspRouter.ts
+++ b/runtimes/runtimes/lsp/router/lspRouter.ts
@@ -221,6 +221,10 @@ ${JSON.stringify({ ...result.capabilities, ...result.awsServerCapabilities })}`
         this.routeNotificationToAllServers((server, type) => server.notifyCredentialsDeletion(type), type)
     }
 
+    onCredentialsUpdate = (type: CredentialsType): void => {
+        this.routeNotificationToAllServers((server, type) => server.notifyCredentialsUpdate(type), type)
+    }
+
     onInitialized = (params: InitializedParams): void => {
         const workspaceCapabilities = this.clientInitializeParams?.capabilities.workspace
         if (workspaceCapabilities?.didChangeConfiguration?.dynamicRegistration) {

--- a/runtimes/runtimes/lsp/router/lspServer.test.ts
+++ b/runtimes/runtimes/lsp/router/lspServer.test.ts
@@ -343,5 +343,30 @@ describe('LspServer', () => {
             assert(credentialsDeleteHandler.calledOnce)
             assert(credentialsDeleteHandler.calledWith(params))
         })
+
+        it('should handle credential update notifications', async () => {
+            const credentialsUpdateHandler = sandbox.stub()
+            const params = 'bearer'
+
+            lspServer.setCredentialsUpdateHandler(credentialsUpdateHandler)
+            lspServer.notifyCredentialsUpdate(params)
+
+            assert(credentialsUpdateHandler.calledOnce)
+            assert(credentialsUpdateHandler.calledWith(params))
+        })
+
+        it('should not throw when no credential update handler is registered', async () => {
+            assert.doesNotThrow(() => lspServer.notifyCredentialsUpdate('bearer'))
+        })
+
+        it('should swallow errors thrown by a credential update handler', async () => {
+            // This runs inside the client's credentials request. A server that throws must not fail
+            // that request, or the client is left believing the credentials never landed.
+            lspServer.setCredentialsUpdateHandler(() => {
+                throw new Error('handler exploded')
+            })
+
+            assert.doesNotThrow(() => lspServer.notifyCredentialsUpdate('bearer'))
+        })
     })
 })

--- a/runtimes/runtimes/lsp/router/lspServer.ts
+++ b/runtimes/runtimes/lsp/router/lspServer.ts
@@ -42,6 +42,7 @@ export class LspServer {
     private initializedHandler?: NotificationHandler<InitializedParams>
     private updateConfigurationHandler?: RequestHandler<UpdateConfigurationParams, void, void>
     private credentialsDeleteHandler?: (type: CredentialsType) => void
+    private credentialsUpdateHandler?: (type: CredentialsType) => void
 
     private clientSupportsNotifications?: boolean
     private initializeResult?: PartialInitializeResult
@@ -79,6 +80,10 @@ export class LspServer {
 
     setCredentialsDeleteHandler = (handler: (type: CredentialsType) => void): void => {
         this.credentialsDeleteHandler = handler
+    }
+
+    setCredentialsUpdateHandler = (handler: (type: CredentialsType) => void): void => {
+        this.credentialsUpdateHandler = handler
     }
 
     public setInitializedHandler = (handler: NotificationHandler<InitializedParams>): void => {
@@ -244,6 +249,20 @@ export class LspServer {
     notifyCredentialsDeletion = (type: CredentialsType): void => {
         if (this.credentialsDeleteHandler) {
             this.credentialsDeleteHandler(type)
+        }
+    }
+
+    notifyCredentialsUpdate = (type: CredentialsType): void => {
+        if (!this.credentialsUpdateHandler) {
+            return
+        }
+
+        try {
+            this.credentialsUpdateHandler(type)
+        } catch (error) {
+            // This runs inside the client's credentials request. A server that throws here must not
+            // fail that request, or the client is left believing the credentials never landed.
+            this.logger.log(`Credentials update handler threw, ignoring: ${(error as Error)?.message}`)
         }
     }
 }

--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -488,6 +488,7 @@ export const standalone = (props: RuntimeProps) => {
             }
 
             credentialsProvider.onCredentialsDeleted = lspServer.setCredentialsDeleteHandler
+            credentialsProvider.onCredentialsUpdated = lspServer.setCredentialsUpdateHandler
 
             return s({
                 chat,

--- a/runtimes/server-interface/auth.ts
+++ b/runtimes/server-interface/auth.ts
@@ -13,4 +13,18 @@ export interface CredentialsProvider {
     getConnectionMetadata: () => ConnectionMetadata | undefined
     getConnectionType: () => SsoConnectionType
     onCredentialsDeleted: (handler: (type: CredentialsType) => void) => void
+    /**
+     * Notifies the server that credentials of the given type have been stored, so work that depends on
+     * them can start immediately rather than waiting for the first consumer to ask.
+     *
+     * Fired after the credentials are available from {@link getCredentials}, so a handler can read them
+     * synchronously. Handlers must not throw; a throwing handler is logged and ignored so it cannot
+     * fail the client's credentials request.
+     *
+     * Optional so that adding it is not a breaking change: this interface is implemented by test
+     * doubles across several consumers, and requiring a new member would fail their builds on upgrade.
+     * Servers should call it with optional chaining, which also means a server built against this
+     * version still runs on an older runtime -- it simply never gets the event.
+     */
+    onCredentialsUpdated?: (handler: (type: CredentialsType) => void) => void
 }


### PR DESCRIPTION
## Problem

Servers are notified when credentials are **deleted** (`onCredentialsDeleted`) but not when they **arrive**. Anything that depends on credentials therefore cannot start until something else happens to ask for it.

Concretely, in `aws/language-servers` the Q token service issues its first service call from its constructor, and the service is constructed lazily by the first consumer — which in practice is the **chat webview finishing boot**. Measured from a real session:

```
08.176  Runtime: Successfully saved bearer credentials
08.838  chat reports ui-is-ready  ->  aws/chat/ready
08.840  "Detected New connection type: builderId"  ->  Q services constructed
09.740  first service response
```

That's **~0.66s** of avoidable wait before the request even goes out, on top of its own ~0.9s latency.

There is already dead code in `aws/language-servers` reaching for this event:

```ts
if ('onCredentialsUpdated' in credentialsProvider) {
    ;(credentialsProvider as any).onCredentialsUpdated(...)
```

It is guarded by an `in` check and an `any` cast, and has never fired, because the member does not exist. Someone expected this hook to be here.

## Change

Adds `onCredentialsUpdated`, mirroring the deletion path exactly:

| Piece | Deletion (existing) | Update (new) |
|---|---|---|
| Per-server registration | `lspServer.setCredentialsDeleteHandler` | `lspServer.setCredentialsUpdateHandler` |
| Fan-out to all servers | `lspRouter.onCredentialsDeletion` | `lspRouter.onCredentialsUpdate` |
| Server-facing API | `credentialsProvider.onCredentialsDeleted` | `credentialsProvider.onCredentialsUpdated` |

Routed through `lspRouter` rather than the single handler field on `Auth`, so **every** server receives it. `agent-standalone` registers 16 servers; a single-handler design would silently serve only the last subscriber.

Fired from `setCredentials`, which is the one point both the IAM and bearer update paths pass through, and after the credentials are readable so a handler can call `getCredentials` synchronously.

## Two deliberate choices

**Optional on the interface, not required.** `CredentialsProvider` is implemented by test doubles across several consumers of this package, and adding a required member fails their builds on upgrade — it broke two fixtures in this repo when I first tried it. Optional also means a server built against this version still runs on an older runtime and simply never receives the event, which matters because servers ship on a different cadence to runtimes.

**Handler exceptions are swallowed and logged.** This runs inside the client's credentials request. A server that throws must not fail that request, or the client is left believing the credentials never landed.

## Testing

`tsc` clean, prettier clean, 78 passing across `lspServer`, `lspRouter` and `auth` tests. New tests cover: fan-out to all servers, a registered handler, no handler registered, and a handler that throws.

Rebased onto latest `main` (`5bd1e00`) before raising.
